### PR TITLE
feat: support for stdin when using `harvest prepare`

### DIFF
--- a/bin/cmds/harvest/prepare.js
+++ b/bin/cmds/harvest/prepare.js
@@ -175,9 +175,16 @@ function readAllStdin() {
   });
 }
 
+function mergeParams(params, overrides) {
+  const merged = { ...params };
+  Object.keys(overrides)
+    .filter((key) => overrides[key] != null)
+    .forEach((key) => { merged[key] = overrides[key]; });
+  return merged;
+}
+
 exports.handler = async function handler(argv) {
   const {
-    verbose,
     harvestId,
     format: outputFormat,
     $0: scriptName,
@@ -191,11 +198,12 @@ exports.handler = async function handler(argv) {
     sushiIds: argv.sushiIds,
     institutionIds: argv.institutionIds,
     endpointIds: argv.endpointIds,
-    forceDownload: argv.cache === false,
+    forceDownload: argv.cache != null ? argv.cache === false : undefined,
     allowFaulty: argv.allowFaulty,
     timeout: argv.timeout,
     ignoreValidation: argv.ignoreValidation,
     downloadUnsupported: argv.downloadUnsupported,
+    verbose: argv.verbose,
   };
 
   let sessionParams = [{ harvestId }];
@@ -211,11 +219,7 @@ exports.handler = async function handler(argv) {
   }
 
   for (const params of sessionParams) {
-    const session = await prepareSession({
-      ...params,
-      ...overrides,
-      verbose,
-    });
+    const session = await prepareSession(mergeParams(params, overrides));
 
     if (!session) {
       // eslint-disable-next-line no-continue

--- a/bin/cmds/harvest/start.js
+++ b/bin/cmds/harvest/start.js
@@ -25,28 +25,21 @@ exports.builder = (yargs) => yargs
     describe: i18n.t('harvest.start.options.yes'),
     type: 'boolean',
   })
-  .option('j', {
-    alias: 'json',
-    describe: i18n.t('sushi.prepare.harvest.options.json'),
-    type: 'boolean',
-    conflicts: ['n'],
-  })
-  .option('n', {
-    alias: 'ndjson',
-    describe: i18n.t('harvest.prepare.options.ndjson'),
-    type: 'boolean',
-    conflicts: ['j'],
+  .option('format', {
+    type: 'string',
+    choices: ['json', 'ndjson'],
+    describe: i18n.t('harvest.status.options.format'),
   });
 
 const printJobs = (jobs, argv) => {
-  const { json, ndjson } = argv;
+  const { format } = argv;
 
-  if (json) {
+  if (format === 'json') {
     console.log(JSON.stringify(jobs, null, 2));
     return;
   }
 
-  if (ndjson) {
+  if (format === 'ndjson') {
     jobs.forEach((j) => console.log(JSON.stringify(j)));
     return;
   }

--- a/bin/cmds/harvest/status.js
+++ b/bin/cmds/harvest/status.js
@@ -122,7 +122,7 @@ const printOrWatch = async (fnc, argv) => {
 };
 
 const printHarvestStatus = async (sessionStatus, argv) => {
-  const { harvestId, json, verbose } = argv;
+  const { harvestId, output: outputFormat, verbose } = argv;
 
   let printedLines = 0;
   if (verbose) {
@@ -145,7 +145,7 @@ const printHarvestStatus = async (sessionStatus, argv) => {
     process.exit(1);
   }
 
-  if (json) {
+  if (outputFormat === 'json') {
     console.log(JSON.stringify({ session, sessionStatus }, null, 2));
     printedLines += 1;
     return printedLines;
@@ -206,9 +206,7 @@ const printHarvestStatus = async (sessionStatus, argv) => {
 };
 
 const printCredentials = async (argv) => {
-  const {
-    harvestId, json, ndjson, verbose,
-  } = argv;
+  const { harvestId, format: outputFormat, verbose } = argv;
 
   let printedLines = 0;
 
@@ -227,13 +225,13 @@ const printCredentials = async (argv) => {
     process.exit(1);
   }
 
-  if (json) {
+  if (outputFormat === 'json') {
     console.log(JSON.stringify(credentials, null, 2));
     printedLines += 1;
     return printedLines;
   }
 
-  if (ndjson) {
+  if (outputFormat === 'ndjson') {
     credentials.forEach((c) => console.log(JSON.stringify(c)));
     printedLines += credentials.length;
     return printedLines;
@@ -283,8 +281,7 @@ const printCredentials = async (argv) => {
 const printJobs = async (session, argv) => {
   const {
     harvestId,
-    json,
-    ndjson,
+    format: outputFormat,
     verbose,
   } = argv;
 
@@ -305,13 +302,13 @@ const printJobs = async (session, argv) => {
     process.exit(1);
   }
 
-  if (json) {
+  if (outputFormat === 'json') {
     console.log(JSON.stringify(jobs, null, 2));
     printedLines += 1;
     return printedLines;
   }
 
-  if (ndjson) {
+  if (outputFormat === 'ndjson') {
     jobs.forEach((j) => console.log(JSON.stringify(j)));
     printedLines += jobs.length;
     return printedLines;

--- a/bin/cmds/harvest/status.js
+++ b/bin/cmds/harvest/status.js
@@ -40,17 +40,10 @@ exports.builder = (yargs) => yargs
     implies: 'watch',
     group: 'Watch :',
   })
-  .option('j', {
-    alias: 'json',
-    describe: i18n.t('harvest.prepare.options.json'),
-    type: 'boolean',
-    conflicts: ['n'],
-  })
-  .option('n', {
-    alias: 'ndjson',
-    describe: i18n.t('harvest.status.options.ndjson'),
-    type: 'boolean',
-    conflicts: ['j'],
+  .option('format', {
+    type: 'string',
+    choices: ['json', 'ndjson'],
+    describe: i18n.t('harvest.status.options.format'),
   });
 
 const DEF_WATCH_DELAY = 5000;

--- a/locales/en.json
+++ b/locales/en.json
@@ -667,9 +667,9 @@
 		"harvestable": {
 			"description": "Get harvestable institutions",
 			"options": {
+				"format": "Change format of output:\n- json: Print result(s) in json\n- ndjson: Print result(s) in ndjson\n- harvest-options: Print result(s) in json, already formatted to be used with other `harvest prepare`",
 				"allowNotReady": "Allow not ready institutions",
-				"allowHarvested": "Allow already harvested institutions",
-				"short": "Print result(s) in json, with common format (may change in the future)"
+				"allowHarvested": "Allow already harvested institutions"
 			},
 			"name": "Name",
 			"contacts": "Doc Contact(s)",
@@ -1060,8 +1060,7 @@
 		"prepare": {
 			"description": "Prepare a new or existing harvest session",
 			"options": {
-				"all": "Harvest all SUSHI items",
-				"json": "Print result(s) in json",
+				"format": "Change format of output:\n- json: Print result(s) in json",
 				"harvestId": "A specific ID to assign to the harvest session. If already exists, it will update session.",
 				"sushiId": "One or more SUSHI IDs. Harvest SUSHI items that have the given identifiers.",
 				"institutionId": "One or more institution IDs. Harvest SUSHI items that belong to the given institutions.",
@@ -1077,7 +1076,6 @@
 			"success": "✔️ Harvest session [{{id}}] is ready to be harvested",
 			"invalidDate": "x Invalid date",
 			"noFilter": "x No filter specified.",
-			"pleaseSetAllFlag": "i Please explicitly set --all flag to harvest all SUSHI items",
 			"runStartCommand": "i Run the following command in order to start the created session:",
 			"runStatusCommand": "i Run the following command in order to get more info about the session:",
 			"runCredentialsCommand": "i Run the following command in order to get more credentials that will be harvested:"
@@ -1085,7 +1083,7 @@
 		"status": {
 			"description": "Get info about an harvest sessions",
 			"options": {
-				"ndjson": "Print result(s) in ndjson",
+				"format": "Change format of output:\n- json: Print result(s) in json\n- ndjson: Print result(s) in ndjson",
 				"harvestId": "Specific ID of the harvest session",
 				"credentials": "Show credentials that will be harvested when starting, not the one provided. Not usable with jobs or watch",
 				"jobs": "Show jobs of the harvest session. Not usable with credentials",

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "lodash.set": "^4.3.2",
         "lodash.unset": "^4.5.2",
         "papaparse": "^5.3.1",
+        "slugify": "^1.6.6",
         "table": "^6.7.1",
         "uuid": "^8.3.2",
         "yargs": "^16.2.0"
@@ -6202,6 +6203,14 @@
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/slugify": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.6.tgz",
+      "integrity": "sha512-h+z7HKHYXj6wJU+AnS/+IH8Uh9fdcX1Lrhg1/VMdf9PwoBQXFcXiAdsy2tSK0P6gKwJLXp02r90ahUCqHk9rrw==",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/source-map": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "lodash.set": "^4.3.2",
     "lodash.unset": "^4.5.2",
     "papaparse": "^5.3.1",
+    "slugify": "^1.6.6",
     "table": "^6.7.1",
     "uuid": "^8.3.2",
     "yargs": "^16.2.0"


### PR DESCRIPTION
## `harvest prepare` support files via stdin

You can pass session parameters through stdin :

```bash
$ eza harvest prepare < "{ \"harvestId\": \"123456\", \"institutionIds\": [\"1\",\"2\"]  }"
```

If given an array, it'll create multiple harvest sessions.

## Merged format options

For few commands (`institutions harvestable`, `harvest *`) you can now pas `--format=json` instead of `--json`. Also added `--format=harvest-options` to some commands, outputing a file that you can pass to `havest preprare`.

```bash
$ eza institutions harvestable --format=harvest-options > harvest_sessions_of_today.json
$ eza harvest prepare < harvest_sessions_of_today.json
```

## Added `dowload-unsupported` option to `harvest prepare`
